### PR TITLE
bugfix: replace placeholder video arrays with empty arrays in events

### DIFF
--- a/content/events.json
+++ b/content/events.json
@@ -45,7 +45,7 @@
       "videos": {
         "sectionTitle": "📹 The full playlist",
         "sectionContent": {
-          "value": ["array", "of", "videos"]
+          "value": []
         }
       },
       "agenda": {
@@ -146,7 +146,7 @@
       "videos": {
         "sectionTitle": "📹 The full playlist",
         "sectionContent": {
-          "value": ["array", "of", "videos"]
+          "value": []
         }
       },
       "agenda": {
@@ -965,7 +965,7 @@
       "videos": {
         "sectionTitle": "📹 The full playlist",
         "sectionContent": {
-          "value": ["array", "of", "videos"]
+          "value": []
         }
       },
       "agenda": {
@@ -1175,7 +1175,7 @@
       "videos": {
         "sectionTitle": "📹 The full playlist",
         "sectionContent": {
-          "value": ["array", "of", "videos"]
+          "value": []
         }
       },
       "agenda": {
@@ -1274,7 +1274,7 @@
       "videos": {
         "sectionTitle": "📹 The full playlist",
         "sectionContent": {
-          "value": ["array", "of", "videos"]
+          "value": []
         }
       },
       "agenda": {


### PR DESCRIPTION
# Fix: Replace placeholder video arrays with empty arrays in events

Replaced placeholder text ["array", "of", "videos"] with empty arrays [] in the videos section of 5 events in events.json.
